### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include readme.md

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", encoding='utf-8') as fh:
+with open("readme.md", encoding='utf-8') as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Include missing files in sdist for #2

Tested with

```
+++ mktemp -d
++ D=/tmp/tmp.4ijgWm9A5k
++ trap 'rm -rf /tmp/tmp.4ijgWm9A5k' EXIT
++ python -m venv /tmp/tmp.4ijgWm9A5k
++ python setup.py sdist -d /tmp/tmp.4ijgWm9A5k
Warning: 'classifiers' should be a list, got type 'tuple'
running sdist
running egg_info
writing dftserialize.egg-info/PKG-INFO
writing dependency_links to dftserialize.egg-info/dependency_links.txt
writing requirements to dftserialize.egg-info/requires.txt
writing top-level names to dftserialize.egg-info/top_level.txt
reading manifest file 'dftserialize.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'dftserialize.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md

running check
creating dftserialize-0.2.0
creating dftserialize-0.2.0/dftserialize
creating dftserialize-0.2.0/dftserialize.egg-info
copying files to dftserialize-0.2.0...
copying MANIFEST.in -> dftserialize-0.2.0
copying readme.md -> dftserialize-0.2.0
copying setup.py -> dftserialize-0.2.0
copying dftserialize/__init__.py -> dftserialize-0.2.0/dftserialize
copying dftserialize/deserialize.py -> dftserialize-0.2.0/dftserialize
copying dftserialize/serialize.py -> dftserialize-0.2.0/dftserialize
copying dftserialize.egg-info/PKG-INFO -> dftserialize-0.2.0/dftserialize.egg-info
copying dftserialize.egg-info/SOURCES.txt -> dftserialize-0.2.0/dftserialize.egg-info
copying dftserialize.egg-info/dependency_links.txt -> dftserialize-0.2.0/dftserialize.egg-info
copying dftserialize.egg-info/requires.txt -> dftserialize-0.2.0/dftserialize.egg-info
copying dftserialize.egg-info/top_level.txt -> dftserialize-0.2.0/dftserialize.egg-info
Writing dftserialize-0.2.0/setup.cfg
Creating tar archive
removing 'dftserialize-0.2.0' (and everything under it)
++ /tmp/tmp.4ijgWm9A5k/bin/pip install /tmp/tmp.4ijgWm9A5k/dftserialize-0.2.0.tar.gz
Processing /tmp/tmp.4ijgWm9A5k/dftserialize-0.2.0.tar.gz
Collecting numpy (from dftserialize==0.2.0)
  Using cached https://files.pythonhosted.org/packages/cf/5d/e8198f11dd73a91f7bde15ca88a2b78913fa2b416ae2dc2a6aeafcf4c63d/numpy-1.18.4-cp38-cp38-manylinux1_x86_64.whl
Installing collected packages: numpy, dftserialize
  Running setup.py install for dftserialize: started
    Running setup.py install for dftserialize: finished with status 'done'
Successfully installed dftserialize-0.2.0 numpy-1.18.4
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
++ echo Success
Success
+++ rm -rf /tmp/tmp.4ijgWm9A5k
```
